### PR TITLE
Fix build errors due to missing namespace imports

### DIFF
--- a/Lugamar VTT/Controllers/CharsheetController.cs
+++ b/Lugamar VTT/Controllers/CharsheetController.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using LugamarVTT.Services;
 using Microsoft.AspNetCore.Mvc;
 

--- a/Lugamar VTT/Models/Character.cs
+++ b/Lugamar VTT/Models/Character.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace LugamarVTT.Models
 {
     /// <summary>


### PR DESCRIPTION
## Summary
- add System.Collections.Generic import for Character model collections
- import System and System.Linq in CharsheetController for Exception and LINQ usage

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af3bd4807c83309cb8d231ef38796f