### PR TITLE
style: lay out character sheet using pdf template

### DIFF
--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -1,76 +1,112 @@
 @model LugamarVTT.Models.Character
+@using System
 
 @{
-    // Use the character name for the page title when available
     ViewData["Title"] = Model?.Name ?? "Character Details";
 }
 
-<h1 class="mt-4 mb-3">@Model?.Name</h1>
+@section Styles {
+    <link rel="stylesheet" href="~/css/charsheet.css" />
+}
 
+@functions {
+    int Mod(int score) => (int)Math.Floor((score - 10) / 2.0);
+}
+
+<h1 class="mt-4 mb-3">@Model?.Name</h1>
 <a asp-action="Index" class="btn btn-secondary mb-3">&larr; Back to list</a>
 
-<div class="card">
-    <div class="card-body">
-        <h2 class="h5">Basic Information</h2>
-        <dl class="row">
-            <dt class="col-sm-3">Race</dt>
-            <dd class="col-sm-9">@Model?.Race</dd>
-            <dt class="col-sm-3">Class</dt>
-            <dd class="col-sm-9">@Model?.Class</dd>
-            <dt class="col-sm-3">Alignment</dt>
-            <dd class="col-sm-9">@Model?.Alignment</dd>
-            <dt class="col-sm-3">Level</dt>
-            <dd class="col-sm-9">@Model?.Level</dd>
-        </dl>
+<div class="charsheet">
+    <aside class="ability-scores">
+        <div class="ability">
+            <span class="label">STR</span>
+            <span class="score">@Model?.Strength</span>
+            <span class="mod">@Mod(Model?.Strength ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">DEX</span>
+            <span class="score">@Model?.Dexterity</span>
+            <span class="mod">@Mod(Model?.Dexterity ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">CON</span>
+            <span class="score">@Model?.Constitution</span>
+            <span class="mod">@Mod(Model?.Constitution ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">INT</span>
+            <span class="score">@Model?.Intelligence</span>
+            <span class="mod">@Mod(Model?.Intelligence ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">WIS</span>
+            <span class="score">@Model?.Wisdom</span>
+            <span class="mod">@Mod(Model?.Wisdom ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">CHA</span>
+            <span class="score">@Model?.Charisma</span>
+            <span class="mod">@Mod(Model?.Charisma ?? 0)</span>
+        </div>
+    </aside>
 
-        <h2 class="h5 mt-4">Ability Scores</h2>
-        <dl class="row">
-            <dt class="col-sm-3">Strength</dt>
-            <dd class="col-sm-9">@Model?.Strength</dd>
-            <dt class="col-sm-3">Dexterity</dt>
-            <dd class="col-sm-9">@Model?.Dexterity</dd>
-            <dt class="col-sm-3">Constitution</dt>
-            <dd class="col-sm-9">@Model?.Constitution</dd>
-            <dt class="col-sm-3">Intelligence</dt>
-            <dd class="col-sm-9">@Model?.Intelligence</dd>
-            <dt class="col-sm-3">Wisdom</dt>
-            <dd class="col-sm-9">@Model?.Wisdom</dd>
-            <dt class="col-sm-3">Charisma</dt>
-            <dd class="col-sm-9">@Model?.Charisma</dd>
-        </dl>
+    <section>
+        <div class="section basic-info">
+            <h2>Basic Information</h2>
+            <dl class="row">
+                <dt class="col-sm-3">Race</dt>
+                <dd class="col-sm-9">@Model?.Race</dd>
+                <dt class="col-sm-3">Class</dt>
+                <dd class="col-sm-9">@Model?.Class</dd>
+                <dt class="col-sm-3">Alignment</dt>
+                <dd class="col-sm-9">@Model?.Alignment</dd>
+                <dt class="col-sm-3">Level</dt>
+                <dd class="col-sm-9">@Model?.Level</dd>
+            </dl>
+        </div>
 
-        <h2 class="h5 mt-4">Combat Statistics</h2>
-        <dl class="row">
-            <dt class="col-sm-3">Armor Class</dt>
-            <dd class="col-sm-9">@Model?.ArmorClass</dd>
-            <dt class="col-sm-3">Hit Points</dt>
-            <dd class="col-sm-9">@Model?.HitPoints</dd>
-            <dt class="col-sm-3">Base Attack Bonus</dt>
-            <dd class="col-sm-9">@Model?.BaseAttackBonus</dd>
-        </dl>
+        <div class="section combat-stats">
+            <h2>Combat Statistics</h2>
+            <dl class="row">
+                <dt class="col-sm-4">Armor Class</dt>
+                <dd class="col-sm-8">@Model?.ArmorClass</dd>
+                <dt class="col-sm-4">Hit Points</dt>
+                <dd class="col-sm-8">@Model?.HitPoints</dd>
+                <dt class="col-sm-4">Base Attack Bonus</dt>
+                <dd class="col-sm-8">@Model?.BaseAttackBonus</dd>
+            </dl>
+        </div>
 
         @if (Model != null && Model.Skills.Any())
         {
-            <h2 class="h5 mt-4">Skills</h2>
-            <p>@string.Join(", ", Model.Skills)</p>
+            <div class="section">
+                <h2>Skills</h2>
+                <p>@string.Join(", ", Model.Skills)</p>
+            </div>
         }
 
         @if (Model != null && Model.Feats.Any())
         {
-            <h2 class="h5 mt-4">Feats</h2>
-            <p>@string.Join(", ", Model.Feats)</p>
+            <div class="section">
+                <h2>Feats</h2>
+                <p>@string.Join(", ", Model.Feats)</p>
+            </div>
         }
 
         @if (Model != null && Model.Equipment.Any())
         {
-            <h2 class="h5 mt-4">Equipment</h2>
-            <p>@string.Join(", ", Model.Equipment)</p>
+            <div class="section">
+                <h2>Equipment</h2>
+                <p>@string.Join(", ", Model.Equipment)</p>
+            </div>
         }
 
         @if (Model != null && Model.Spells.Any())
         {
-            <h2 class="h5 mt-4">Spells</h2>
-            <p>@string.Join(", ", Model.Spells)</p>
+            <div class="section">
+                <h2>Spells</h2>
+                <p>@string.Join(", ", Model.Spells)</p>
+            </div>
         }
-    </div>
+    </section>
 </div>

--- a/Lugamar VTT/Views/Shared/_Layout.cshtml
+++ b/Lugamar VTT/Views/Shared/_Layout.cshtml
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
           integrity="sha384-lZN37f0uwDP7e9/70aBmxBvj+0q6Uptz1W6r4IbZci8s2Z/HAbUiu1q8PUM6cxC5"
           crossorigin="anonymous">
+    @RenderSection("Styles", required: false)
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">

--- a/Lugamar VTT/wwwroot/css/charsheet.css
+++ b/Lugamar VTT/wwwroot/css/charsheet.css
@@ -1,0 +1,43 @@
+.charsheet {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 1rem;
+}
+
+.ability-scores {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.ability {
+    border: 2px solid #000;
+    text-align: center;
+    padding: 0.5rem;
+    background-color: #f8f9fa;
+}
+
+.ability .label {
+    font-weight: bold;
+    font-size: 0.8rem;
+}
+
+.ability .score {
+    font-size: 1.5rem;
+    font-weight: bold;
+    display: block;
+}
+
+.ability .mod {
+    font-size: 1rem;
+    display: block;
+}
+
+.section {
+    margin-bottom: 1rem;
+}
+
+.section h2 {
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add style section in layout for view-specific CSS
- redesign character detail view with ability score grid based on PDF layout
- provide dedicated charsheet stylesheet

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6780d8e88330b1b833c3f2cdfdc5