### PR TITLE
feat: surface attack bonuses and cmd breakdown

### DIFF
--- a/Lugamar VTT/Models/ArmorClassDetail.cs
+++ b/Lugamar VTT/Models/ArmorClassDetail.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents the components that make up an armor class calculation.
+    /// </summary>
+    public class ArmorClassDetail
+    {
+        public int DexModifier { get; set; }
+        public int SizeModifier { get; set; }
+        public int ArmorBonus { get; set; }
+        public int ShieldBonus { get; set; }
+        public int NaturalArmor { get; set; }
+        public int Dodge { get; set; }
+        public int Misc { get; set; }
+        public int Deflection { get; set; }
+        public int Temp { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/Lugamar VTT/Models/AttackBonusDetail.cs
+++ b/Lugamar VTT/Models/AttackBonusDetail.cs
@@ -1,0 +1,15 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Breaks down the modifiers that contribute to an attack bonus.
+    /// </summary>
+    public class AttackBonusDetail
+    {
+        public int BaseAttackBonus { get; set; }
+        public int AbilityMod { get; set; }
+        public int SizeBonus { get; set; }
+        public int Misc { get; set; }
+        public int Temp { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/Lugamar VTT/Models/Character.cs
+++ b/Lugamar VTT/Models/Character.cs
@@ -35,13 +35,43 @@ namespace LugamarVTT.Models
 
         // Combat statistics
         public int ArmorClass { get; set; }
+        public int TouchArmorClass { get; set; }
+        public int FlatFootedArmorClass { get; set; }
+
+        public ArmorClassDetail ArmorClassBreakdown { get; set; } = new();
+        public ArmorClassDetail TouchArmorClassBreakdown { get; set; } = new();
+        public ArmorClassDetail FlatFootedArmorClassBreakdown { get; set; } = new();
         public int HitPoints { get; set; }
-        public string? BaseAttackBonus { get; set; }
+        public int CurrentHitPoints { get; set; }
+        public int Fortitude { get; set; }
+        public int Reflex { get; set; }
+        public int Will { get; set; }
+        public int Initiative { get; set; }
+        public int Speed { get; set; }
+        public int BaseAttackBonus { get; set; }
+        public AttackBonusDetail MeleeAttackBonus { get; set; } = new();
+        public AttackBonusDetail RangedAttackBonus { get; set; } = new();
+        public AttackBonusDetail CombatManeuverBonus { get; set; } = new();
+        public CmdDetail CombatManeuverDefense { get; set; } = new();
+
+        // Skill tracking
+        public int SkillPointsSpent { get; set; }
 
         // Optional collections for skills, feats, equipment and spells
         public List<string> Skills { get; set; } = new();
+        public List<SkillDetail> SkillDetails { get; set; } = new();
+
         public List<string> Feats { get; set; } = new();
+        public List<FeatDetail> FeatDetails { get; set; } = new();
+
+        public List<SpecialAbility> SpecialAbilities { get; set; } = new();
+        public List<Trait> Traits { get; set; } = new();
+
+        public List<string> Proficiencies { get; set; } = new();
+
         public List<string> Equipment { get; set; } = new();
+        public List<EquipmentItem> EquipmentDetails { get; set; } = new();
+
         public List<string> Spells { get; set; } = new();
     }
 }

--- a/Lugamar VTT/Models/CmdDetail.cs
+++ b/Lugamar VTT/Models/CmdDetail.cs
@@ -1,0 +1,15 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents the components that make up a combat maneuver defense value.
+    /// </summary>
+    public class CmdDetail
+    {
+        public int BaseAttackBonus { get; set; }
+        public int StrBonus { get; set; }
+        public int DexBonus { get; set; }
+        public int SizeBonus { get; set; }
+        public int Misc { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/Lugamar VTT/Models/EquipmentItem.cs
+++ b/Lugamar VTT/Models/EquipmentItem.cs
@@ -1,0 +1,17 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents an inventory item including its categorisation and
+    /// descriptive fields used for the character sheet.
+    /// </summary>
+    public class EquipmentItem
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string Subtype { get; set; } = string.Empty;
+        public string Cost { get; set; } = string.Empty;
+        public string Weight { get; set; } = string.Empty;
+        /// <summary>Formatted description of the item.</summary>
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/Lugamar VTT/Models/FeatDetail.cs
+++ b/Lugamar VTT/Models/FeatDetail.cs
@@ -1,0 +1,17 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Detailed information about a feat including prerequisite text and
+    /// formatted benefit descriptions.
+    /// </summary>
+    public class FeatDetail
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Summary { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string Prerequisites { get; set; } = string.Empty;
+        public string Benefit { get; set; } = string.Empty;
+        public string Normal { get; set; } = string.Empty;
+        public string Special { get; set; } = string.Empty;
+    }
+}

--- a/Lugamar VTT/Models/SkillDetail.cs
+++ b/Lugamar VTT/Models/SkillDetail.cs
@@ -1,0 +1,26 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents a single skill entry including its ranks, miscellaneous
+    /// modifier and final total bonus.
+    /// </summary>
+    public class SkillDetail
+    {
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>Abbreviated ability that powers this skill (e.g. STR, DEX).</summary>
+        public string Ability { get; set; } = string.Empty;
+
+        /// <summary>Modifier derived from the associated ability score.</summary>
+        public int AbilityBonus { get; set; }
+
+        /// <summary>Number of skill ranks invested by the character.</summary>
+        public int Ranks { get; set; }
+
+        /// <summary>Miscellaneous modifier applied to the skill.</summary>
+        public int Misc { get; set; }
+
+        /// <summary>Total bonus after applying ability modifier, ranks and misc.</summary>
+        public int Total { get; set; }
+    }
+}

--- a/Lugamar VTT/Models/SpecialAbility.cs
+++ b/Lugamar VTT/Models/SpecialAbility.cs
@@ -1,0 +1,14 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents a special ability a character possesses, including the
+    /// source of the ability and its descriptive text.
+    /// </summary>
+    public class SpecialAbility
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Source { get; set; } = string.Empty;
+        /// <summary>Formatted description of the ability.</summary>
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/Lugamar VTT/Models/Trait.cs
+++ b/Lugamar VTT/Models/Trait.cs
@@ -1,0 +1,14 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents a character trait drawn from the XML including its source
+    /// classification and descriptive text.
+    /// </summary>
+    public class Trait
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Source { get; set; } = string.Empty;
+        /// <summary>Formatted description of the trait.</summary>
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -1,76 +1,463 @@
 @model LugamarVTT.Models.Character
+@using System
+@using System.Linq
 
 @{
-    // Use the character name for the page title when available
     ViewData["Title"] = Model?.Name ?? "Character Details";
 }
 
-<h1 class="mt-4 mb-3">@Model?.Name</h1>
+@section Styles {
+    <link rel="stylesheet" href="~/css/charsheet.css" />
+}
 
+@functions {
+    int Mod(int score) => (int)Math.Floor((score - 10) / 2.0);
+}
+
+<h1 class="mt-4 mb-3">@Model?.Name</h1>
 <a asp-action="Index" class="btn btn-secondary mb-3">&larr; Back to list</a>
 
-<div class="card">
-    <div class="card-body">
-        <h2 class="h5">Basic Information</h2>
-        <dl class="row">
-            <dt class="col-sm-3">Race</dt>
-            <dd class="col-sm-9">@Model?.Race</dd>
-            <dt class="col-sm-3">Class</dt>
-            <dd class="col-sm-9">@Model?.Class</dd>
-            <dt class="col-sm-3">Alignment</dt>
-            <dd class="col-sm-9">@Model?.Alignment</dd>
-            <dt class="col-sm-3">Level</dt>
-            <dd class="col-sm-9">@Model?.Level</dd>
-        </dl>
+<div class="charsheet">
+    <aside class="ability-scores">
+        <div class="ability">
+            <span class="label">STR</span>
+            <span class="score">@Model?.Strength</span>
+            <span class="mod">@Mod(Model?.Strength ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">DEX</span>
+            <span class="score">@Model?.Dexterity</span>
+            <span class="mod">@Mod(Model?.Dexterity ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">CON</span>
+            <span class="score">@Model?.Constitution</span>
+            <span class="mod">@Mod(Model?.Constitution ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">INT</span>
+            <span class="score">@Model?.Intelligence</span>
+            <span class="mod">@Mod(Model?.Intelligence ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">WIS</span>
+            <span class="score">@Model?.Wisdom</span>
+            <span class="mod">@Mod(Model?.Wisdom ?? 0)</span>
+        </div>
+        <div class="ability">
+            <span class="label">CHA</span>
+            <span class="score">@Model?.Charisma</span>
+            <span class="mod">@Mod(Model?.Charisma ?? 0)</span>
+        </div>
+    </aside>
 
-        <h2 class="h5 mt-4">Ability Scores</h2>
-        <dl class="row">
-            <dt class="col-sm-3">Strength</dt>
-            <dd class="col-sm-9">@Model?.Strength</dd>
-            <dt class="col-sm-3">Dexterity</dt>
-            <dd class="col-sm-9">@Model?.Dexterity</dd>
-            <dt class="col-sm-3">Constitution</dt>
-            <dd class="col-sm-9">@Model?.Constitution</dd>
-            <dt class="col-sm-3">Intelligence</dt>
-            <dd class="col-sm-9">@Model?.Intelligence</dd>
-            <dt class="col-sm-3">Wisdom</dt>
-            <dd class="col-sm-9">@Model?.Wisdom</dd>
-            <dt class="col-sm-3">Charisma</dt>
-            <dd class="col-sm-9">@Model?.Charisma</dd>
-        </dl>
+    <div class="main">
+        <div class="section basic-info">
+            <h2>Character Information</h2>
+            <dl class="row">
+                <dt class="col-sm-3">Race</dt>
+                <dd class="col-sm-9">@Model?.Race</dd>
+                <dt class="col-sm-3">Class</dt>
+                <dd class="col-sm-9">@Model?.Class</dd>
+                <dt class="col-sm-3">Alignment</dt>
+                <dd class="col-sm-9">@Model?.Alignment</dd>
+                <dt class="col-sm-3">Level</dt>
+                <dd class="col-sm-9">@Model?.Level</dd>
+            </dl>
+        </div>
 
-        <h2 class="h5 mt-4">Combat Statistics</h2>
-        <dl class="row">
-            <dt class="col-sm-3">Armor Class</dt>
-            <dd class="col-sm-9">@Model?.ArmorClass</dd>
-            <dt class="col-sm-3">Hit Points</dt>
-            <dd class="col-sm-9">@Model?.HitPoints</dd>
-            <dt class="col-sm-3">Base Attack Bonus</dt>
-            <dd class="col-sm-9">@Model?.BaseAttackBonus</dd>
-        </dl>
+        <div class="section hp">
+            <h2>Hit Points</h2>
+            <dl class="row">
+                <dt class="col-sm-4">Current</dt>
+                <dd class="col-sm-8">@Model?.CurrentHitPoints</dd>
+                <dt class="col-sm-4">Total</dt>
+                <dd class="col-sm-8">@Model?.HitPoints</dd>
+            </dl>
+        </div>
 
-        @if (Model != null && Model.Skills.Any())
+        <div class="section saves">
+            <h2>Saving Throws</h2>
+            <dl class="row">
+                <dt class="col-sm-4">Fortitude</dt>
+                <dd class="col-sm-8">@Model?.Fortitude</dd>
+                <dt class="col-sm-4">Reflex</dt>
+                <dd class="col-sm-8">@Model?.Reflex</dd>
+                <dt class="col-sm-4">Will</dt>
+                <dd class="col-sm-8">@Model?.Will</dd>
+            </dl>
+        </div>
+
+        <div class="section speed-init">
+            <h2>Speed &amp; Initiative</h2>
+            <dl class="row">
+                <dt class="col-sm-4">Speed</dt>
+                <dd class="col-sm-8">@Model?.Speed</dd>
+                <dt class="col-sm-4">Initiative</dt>
+                <dd class="col-sm-8">@Model?.Initiative</dd>
+            </dl>
+        </div>
+
+        <div class="section armor-class">
+            <h2>Armor Class</h2>
+            <table class="sheet-table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>DEX Modifier</th>
+                        <th>Size Modifier</th>
+                        <th>Armor Bonus</th>
+                        <th>Shield Bonus</th>
+                        <th>Natural Armor</th>
+                        <th>Dodge</th>
+                        <th>Misc</th>
+                        <th>Deflection</th>
+                        <th>Temp</th>
+                        <th>Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Armor Class</td>
+                        <td>@Model?.ArmorClassBreakdown.DexModifier</td>
+                        <td>@Model?.ArmorClassBreakdown.SizeModifier</td>
+                        <td>@Model?.ArmorClassBreakdown.ArmorBonus</td>
+                        <td>@Model?.ArmorClassBreakdown.ShieldBonus</td>
+                        <td>@Model?.ArmorClassBreakdown.NaturalArmor</td>
+                        <td>@Model?.ArmorClassBreakdown.Dodge</td>
+                        <td>@Model?.ArmorClassBreakdown.Misc</td>
+                        <td>@Model?.ArmorClassBreakdown.Deflection</td>
+                        <td>@Model?.ArmorClassBreakdown.Temp</td>
+                        <td>@Model?.ArmorClassBreakdown.Total</td>
+                    </tr>
+                    <tr>
+                        <td>Touch</td>
+                        <td>@Model?.TouchArmorClassBreakdown.DexModifier</td>
+                        <td>@Model?.TouchArmorClassBreakdown.SizeModifier</td>
+                        <td class="disabled-cell">@Model?.TouchArmorClassBreakdown.ArmorBonus</td>
+                        <td class="disabled-cell">@Model?.TouchArmorClassBreakdown.ShieldBonus</td>
+                        <td class="disabled-cell">@Model?.TouchArmorClassBreakdown.NaturalArmor</td>
+                        <td>@Model?.TouchArmorClassBreakdown.Dodge</td>
+                        <td>@Model?.TouchArmorClassBreakdown.Misc</td>
+                        <td>@Model?.TouchArmorClassBreakdown.Deflection</td>
+                        <td>@Model?.TouchArmorClassBreakdown.Temp</td>
+                        <td>@Model?.TouchArmorClassBreakdown.Total</td>
+                    </tr>
+                    <tr>
+                        <td>Flat-Footed</td>
+                        <td class="disabled-cell">@Model?.FlatFootedArmorClassBreakdown.DexModifier</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.SizeModifier</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.ArmorBonus</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.ShieldBonus</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.NaturalArmor</td>
+                        <td class="disabled-cell">@Model?.FlatFootedArmorClassBreakdown.Dodge</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.Misc</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.Deflection</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.Temp</td>
+                        <td>@Model?.FlatFootedArmorClassBreakdown.Total</td>
+                    </tr>
+                </tbody>
+            </table>
+            <table class="sheet-table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>Base Attack Bonus</th>
+                        <th>STR Bonus</th>
+                        <th>DEX Bonus</th>
+                        <th>Size Bonus</th>
+                        <th>Misc</th>
+                        <th>Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>CMD</td>
+                        <td>@Model?.CombatManeuverDefense.BaseAttackBonus</td>
+                        <td>@Model?.CombatManeuverDefense.StrBonus</td>
+                        <td>@Model?.CombatManeuverDefense.DexBonus</td>
+                        <td>@Model?.CombatManeuverDefense.SizeBonus</td>
+                        <td>@Model?.CombatManeuverDefense.Misc</td>
+                        <td>@Model?.CombatManeuverDefense.Total</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="section attack-bonus">
+            <h2>Attack Bonus</h2>
+            <table class="sheet-table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>Base Attack Bonus</th>
+                        <th>STR Bonus</th>
+                        <th>DEX Bonus</th>
+                        <th>Size Bonus</th>
+                        <th>Misc</th>
+                        <th>Temp</th>
+                        <th>Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Base Attack Bonus</td>
+                        <td colspan="7">@Model?.BaseAttackBonus</td>
+                    </tr>
+                    <tr>
+                        <td>Melee Attack</td>
+                        <td>@Model?.MeleeAttackBonus.BaseAttackBonus</td>
+                        <td>@Model?.MeleeAttackBonus.AbilityMod</td>
+                        <td class="disabled-cell"></td>
+                        <td>@Model?.MeleeAttackBonus.SizeBonus</td>
+                        <td>@Model?.MeleeAttackBonus.Misc</td>
+                        <td>@Model?.MeleeAttackBonus.Temp</td>
+                        <td>@Model?.MeleeAttackBonus.Total</td>
+                    </tr>
+                    <tr>
+                        <td>Ranged Attack</td>
+                        <td>@Model?.RangedAttackBonus.BaseAttackBonus</td>
+                        <td class="disabled-cell"></td>
+                        <td>@Model?.RangedAttackBonus.AbilityMod</td>
+                        <td>@Model?.RangedAttackBonus.SizeBonus</td>
+                        <td>@Model?.RangedAttackBonus.Misc</td>
+                        <td>@Model?.RangedAttackBonus.Temp</td>
+                        <td>@Model?.RangedAttackBonus.Total</td>
+                    </tr>
+                    <tr>
+                        <td>CMB</td>
+                        <td>@Model?.CombatManeuverBonus.BaseAttackBonus</td>
+                        <td class="disabled-cell"></td>
+                        <td>@Model?.CombatManeuverBonus.AbilityMod</td>
+                        <td>@Model?.CombatManeuverBonus.SizeBonus</td>
+                        <td>@Model?.CombatManeuverBonus.Misc</td>
+                        <td>@Model?.CombatManeuverBonus.Temp</td>
+                        <td>@Model?.CombatManeuverBonus.Total</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        @if (Model != null && Model.SkillDetails.Any())
         {
-            <h2 class="h5 mt-4">Skills</h2>
-            <p>@string.Join(", ", Model.Skills)</p>
+            <div class="section skills-section">
+                <h2>Skills (@Model.SkillPointsSpent spent)</h2>
+                <table class="sheet-table">
+                    <thead>
+                        <tr>
+                            <th>Skill</th>
+                            <th>Ability</th>
+                            <th>Ability Bonus</th>
+                            <th>Ranks</th>
+                            <th>Misc</th>
+                            <th>Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var skill in Model.SkillDetails)
+                        {
+                            <tr>
+                                <td>@skill.Name</td>
+                                <td>@skill.Ability</td>
+                                <td>@skill.AbilityBonus</td>
+                                <td>@skill.Ranks</td>
+                                <td>@skill.Misc</td>
+                                <td>@skill.Total</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
         }
 
-        @if (Model != null && Model.Feats.Any())
+        @if (Model != null && Model.SpecialAbilities.Any())
         {
-            <h2 class="h5 mt-4">Feats</h2>
-            <p>@string.Join(", ", Model.Feats)</p>
+            <div class="section">
+                <h2>Special Abilities</h2>
+                <table class="sheet-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Source</th>
+                            <th>Text</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var ability in Model.SpecialAbilities)
+                        {
+                            <tr>
+                                <td>@ability.Name</td>
+                                <td>@ability.Source</td>
+                                <td>@Html.Raw(ability.Text)</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
         }
 
-        @if (Model != null && Model.Equipment.Any())
+        @if (Model != null && Model.FeatDetails.Any())
         {
-            <h2 class="h5 mt-4">Equipment</h2>
-            <p>@string.Join(", ", Model.Equipment)</p>
+            <div class="section feats-section">
+                <h2>Feats</h2>
+                <table class="sheet-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Summary</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (int i = 0; i < Model.FeatDetails.Count; i++)
+                        {
+                            var feat = Model.FeatDetails[i];
+                            var modalId = $"featModal{i}";
+                            <tr data-bs-toggle="modal" data-bs-target="#@modalId" style="cursor:pointer">
+                                <td>@feat.Name</td>
+                                <td>@feat.Summary</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+                @for (int i = 0; i < Model.FeatDetails.Count; i++)
+                {
+                    var feat = Model.FeatDetails[i];
+                    var modalId = $"featModal{i}";
+                    <div class="modal fade" id="@modalId" tabindex="-1" aria-hidden="true">
+                        <div class="modal-dialog modal-lg">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title">@feat.Name</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <dl>
+                                        <dt>Type</dt><dd>@feat.Type</dd>
+                                        @if (!string.IsNullOrEmpty(feat.Prerequisites))
+                                        {
+                                            <dt>Prerequisites</dt><dd>@feat.Prerequisites</dd>
+                                        }
+                                        @if (!string.IsNullOrEmpty(feat.Benefit))
+                                        {
+                                            <dt>Benefit</dt><dd>@Html.Raw(feat.Benefit)</dd>
+                                        }
+                                        @if (!string.IsNullOrEmpty(feat.Normal))
+                                        {
+                                            <dt>Normal</dt><dd>@Html.Raw(feat.Normal)</dd>
+                                        }
+                                        @if (!string.IsNullOrEmpty(feat.Special))
+                                        {
+                                            <dt>Special</dt><dd>@Html.Raw(feat.Special)</dd>
+                                        }
+                                    </dl>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+
+        @if (Model != null && Model.Traits.Any())
+        {
+            <div class="section">
+                <h2>Traits</h2>
+                <table class="sheet-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Source</th>
+                            <th>Text</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var trait in Model.Traits)
+                        {
+                            <tr>
+                                <td>@trait.Name</td>
+                                <td>@trait.Source</td>
+                                <td>@Html.Raw(trait.Text)</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+
+        @if (Model != null && Model.Proficiencies.Any())
+        {
+            <div class="section">
+                <h2>Proficiencies</h2>
+                <p>@string.Join(", ", Model.Proficiencies)</p>
+            </div>
+        }
+
+        @if (Model != null && Model.EquipmentDetails.Any())
+        {
+            <div class="section equipment-section">
+                <h2>Equipment</h2>
+                @foreach (var group in Model.EquipmentDetails.GroupBy(e => e.Type))
+                {
+                    var items = group.ToList();
+                    var safeType = group.Key.Replace(" ", "");
+                    <h3>@group.Key</h3>
+                    <table class="sheet-table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Subtype</th>
+                                <th>Cost</th>
+                                <th>Weight</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @for (int i = 0; i < items.Count; i++)
+                            {
+                                var item = items[i];
+                                var modalId = $"equipModal_{safeType}_{i}";
+                                <tr data-bs-toggle="modal" data-bs-target="#@modalId" style="cursor:pointer">
+                                    <td>@item.Name</td>
+                                    <td>@item.Subtype</td>
+                                    <td>@item.Cost</td>
+                                    <td>@item.Weight</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                    @for (int i = 0; i < items.Count; i++)
+                    {
+                        var item = items[i];
+                        var modalId = $"equipModal_{safeType}_{i}";
+                        <div class="modal fade" id="@modalId" tabindex="-1" aria-hidden="true">
+                            <div class="modal-dialog modal-lg">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title">@item.Name</h5>
+                                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                                    </div>
+                                    <div class="modal-body">
+                                        <dl>
+                                            <dt>Type</dt><dd>@item.Type</dd>
+                                            <dt>Subtype</dt><dd>@item.Subtype</dd>
+                                            <dt>Cost</dt><dd>@item.Cost</dd>
+                                            <dt>Weight</dt><dd>@item.Weight</dd>
+                                            <dt>Description</dt><dd>@Html.Raw(item.Description)</dd>
+                                        </dl>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+            </div>
         }
 
         @if (Model != null && Model.Spells.Any())
         {
-            <h2 class="h5 mt-4">Spells</h2>
-            <p>@string.Join(", ", Model.Spells)</p>
+            <div class="section">
+                <h2>Spells</h2>
+                <p>@string.Join(", ", Model.Spells)</p>
+            </div>
         }
     </div>
 </div>

--- a/Lugamar VTT/Views/Shared/_Layout.cshtml
+++ b/Lugamar VTT/Views/Shared/_Layout.cshtml
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
           integrity="sha384-lZN37f0uwDP7e9/70aBmxBvj+0q6Uptz1W6r4IbZci8s2Z/HAbUiu1q8PUM6cxC5"
           crossorigin="anonymous">
+    @RenderSection("Styles", required: false)
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">

--- a/Lugamar VTT/wwwroot/css/charsheet.css
+++ b/Lugamar VTT/wwwroot/css/charsheet.css
@@ -1,0 +1,78 @@
+.charsheet {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 1rem;
+}
+
+.ability-scores {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.ability {
+    border: 2px solid #000;
+    text-align: center;
+    padding: 0.5rem;
+    background-color: #f8f9fa;
+}
+
+.ability .label {
+    font-weight: bold;
+    font-size: 0.8rem;
+}
+
+.ability .score {
+    font-size: 1.5rem;
+    font-weight: bold;
+    display: block;
+}
+
+.ability .mod {
+    font-size: 1rem;
+    display: block;
+}
+
+.section {
+    margin-bottom: 1rem;
+}
+
+.section h2 {
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.main {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+}
+
+.skills-section {
+    grid-column: 1 / -1;
+}
+
+.skills-table,
+.sheet-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.skills-table th,
+.skills-table td,
+.sheet-table th,
+.sheet-table td {
+    border: 1px solid #000;
+    padding: 0.25rem;
+    font-size: 0.85rem;
+}
+
+.skills-table th,
+.sheet-table th {
+    background-color: #f0f0f0;
+}
+
+.disabled-cell {
+    background-color: #e9ecef;
+    color: #6c757d;
+}

--- a/LugamarVTT.Tests/XmlDataServiceTests.cs
+++ b/LugamarVTT.Tests/XmlDataServiceTests.cs
@@ -39,14 +39,16 @@ public class XmlDataServiceTests
     <skills>
       <skill name="Acrobatics" />
     </skills>
-    <feats>
-      <feat name="Dodge" />
-    </feats>
-    <equipment>
-      <items>
-        <item name="Sword" />
-      </items>
-    </equipment>
+    <featlist>
+      <id-00001>
+        <name>Dodge</name>
+      </id-00001>
+    </featlist>
+    <inventorylist>
+      <id-00001>
+        <name>Sword</name>
+      </id-00001>
+    </inventorylist>
     <spells>
       <known>
         <spell name="Magic Missile" />
@@ -65,6 +67,136 @@ public class XmlDataServiceTests
             Assert.Contains("Dodge", character.Feats);
             Assert.Contains("Sword", character.Equipment);
             Assert.Contains("Magic Missile", character.Spells);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void GetCharacters_ParsesArmorClassDeflectionAndTemp()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "db.xml"), """
+<root>
+  <charsheet>
+    <ac>
+      <sources>
+        <abilitymod>1</abilitymod>
+        <size>0</size>
+        <armor>4</armor>
+        <shield>2</shield>
+        <naturalarmor>1</naturalarmor>
+        <dodge>1</dodge>
+        <misc>2</misc>
+        <deflection>3</deflection>
+        <temporary>4</temporary>
+        <abilitymod2>0</abilitymod2>
+        <touchmisc>0</touchmisc>
+        <ffmisc>0</ffmisc>
+      </sources>
+      <totals>
+        <general>16</general>
+        <touch>12</touch>
+        <flatfooted>15</flatfooted>
+      </totals>
+    </ac>
+  </charsheet>
+</root>
+""");
+
+            var env = new TestHostEnvironment(tempDir);
+            var service = new XmlDataService(NullLogger<XmlDataService>.Instance, env);
+
+            var character = service.GetCharacters().Single();
+
+            Assert.Equal(3, character.ArmorClassBreakdown.Deflection);
+            Assert.Equal(4, character.ArmorClassBreakdown.Temp);
+            Assert.Equal(2, character.ArmorClassBreakdown.Misc);
+            Assert.Equal(3, character.TouchArmorClassBreakdown.Deflection);
+            Assert.Equal(4, character.TouchArmorClassBreakdown.Temp);
+            Assert.Equal(3, character.FlatFootedArmorClassBreakdown.Deflection);
+            Assert.Equal(4, character.FlatFootedArmorClassBreakdown.Temp);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void GetCharacters_ParsesAttackBonusesAndCmd()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "db.xml"), """
+<root>
+  <charsheet>
+    <ac>
+      <sources>
+        <abilitymod>1</abilitymod>
+        <abilitymod2>2</abilitymod2>
+        <size>1</size>
+        <cmdbasemod>3</cmdbasemod>
+        <cmdmisc>3</cmdmisc>
+      </sources>
+      <totals>
+        <cmd>20</cmd>
+        <general>0</general>
+        <touch>0</touch>
+        <flatfooted>0</flatfooted>
+      </totals>
+    </ac>
+    <attackbonus>
+      <base>5</base>
+      <melee>
+        <abilitymod>1</abilitymod>
+        <size>0</size>
+        <misc>2</misc>
+        <temporary>0</temporary>
+        <total>8</total>
+      </melee>
+      <ranged>
+        <abilitymod>3</abilitymod>
+        <size>0</size>
+        <misc>1</misc>
+        <temporary>0</temporary>
+        <total>9</total>
+      </ranged>
+      <grapple>
+        <abilitymod>2</abilitymod>
+        <size>1</size>
+        <misc>3</misc>
+        <temporary>0</temporary>
+        <total>11</total>
+      </grapple>
+    </attackbonus>
+  </charsheet>
+</root>
+""");
+
+            var env = new TestHostEnvironment(tempDir);
+            var service = new XmlDataService(NullLogger<XmlDataService>.Instance, env);
+
+            var character = service.GetCharacters().Single();
+
+            Assert.Equal(5, character.BaseAttackBonus);
+            Assert.Equal(1, character.MeleeAttackBonus.AbilityMod);
+            Assert.Equal(2, character.MeleeAttackBonus.Misc);
+            Assert.Equal(3, character.RangedAttackBonus.AbilityMod);
+            Assert.Equal(11, character.CombatManeuverBonus.Total);
+            Assert.Equal(3, character.CombatManeuverDefense.BaseAttackBonus);
+            Assert.Equal(1, character.CombatManeuverDefense.StrBonus);
+            Assert.Equal(2, character.CombatManeuverDefense.DexBonus);
+            Assert.Equal(1, character.CombatManeuverDefense.SizeBonus);
+            Assert.Equal(3, character.CombatManeuverDefense.Misc);
+            Assert.Equal(20, character.CombatManeuverDefense.Total);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- model and parse melee, ranged, and combat maneuver attack bonuses from XML
- track combat maneuver defense pieces and display a CMD row alongside armor class
- render an attack bonus table showing base, melee, ranged, and CMB modifiers

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68af6780d8e88330b1b833c3f2cdfdc5