### PR TITLE
Style ability scores card

### DIFF
--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -51,38 +51,86 @@
             <div class="card h-100 shadow-sm">
                 <div class="card-header">Ability Scores</div>
                 <div class="card-body">
-                    <div class="ability-scores">
-                        <div class="ability">
-                            <label>STR</label>
-                            <input class="form-control mb-1 text-center" readonly value="@Model?.Strength" />
-                            <input class="form-control text-center" readonly value="@Mod(Model?.Strength ?? 0)" />
-                        </div>
-                        <div class="ability">
-                            <label>DEX</label>
-                            <input class="form-control mb-1 text-center" readonly value="@Model?.Dexterity" />
-                            <input class="form-control text-center" readonly value="@Mod(Model?.Dexterity ?? 0)" />
-                        </div>
-                        <div class="ability">
-                            <label>CON</label>
-                            <input class="form-control mb-1 text-center" readonly value="@Model?.Constitution" />
-                            <input class="form-control text-center" readonly value="@Mod(Model?.Constitution ?? 0)" />
-                        </div>
-                        <div class="ability">
-                            <label>INT</label>
-                            <input class="form-control mb-1 text-center" readonly value="@Model?.Intelligence" />
-                            <input class="form-control text-center" readonly value="@Mod(Model?.Intelligence ?? 0)" />
-                        </div>
-                        <div class="ability">
-                            <label>WIS</label>
-                            <input class="form-control mb-1 text-center" readonly value="@Model?.Wisdom" />
-                            <input class="form-control text-center" readonly value="@Mod(Model?.Wisdom ?? 0)" />
-                        </div>
-                        <div class="ability">
-                            <label>CHA</label>
-                            <input class="form-control mb-1 text-center" readonly value="@Model?.Charisma" />
-                            <input class="form-control text-center" readonly value="@Mod(Model?.Charisma ?? 0)" />
-                        </div>
-                    </div>
+                    <table class="table table-bordered ability-table mb-0">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>Ability Score</th>
+                                <th>Ability Modifier</th>
+                                <th>Bonus</th>
+                                <th>Penalty</th>
+                                <th>Temp Adjust</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <th class="ability-name">
+                                    <div class="abbr">STR</div>
+                                    <div class="full">Strength</div>
+                                </th>
+                                <td><input class="form-control text-center" readonly value="@Model?.Strength" /></td>
+                                <td><input class="form-control text-center" readonly value="@Mod(Model?.Strength ?? 0)" /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                            </tr>
+                            <tr>
+                                <th class="ability-name">
+                                    <div class="abbr">DEX</div>
+                                    <div class="full">Dexterity</div>
+                                </th>
+                                <td><input class="form-control text-center" readonly value="@Model?.Dexterity" /></td>
+                                <td><input class="form-control text-center" readonly value="@Mod(Model?.Dexterity ?? 0)" /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                            </tr>
+                            <tr>
+                                <th class="ability-name">
+                                    <div class="abbr">CON</div>
+                                    <div class="full">Constitution</div>
+                                </th>
+                                <td><input class="form-control text-center" readonly value="@Model?.Constitution" /></td>
+                                <td><input class="form-control text-center" readonly value="@Mod(Model?.Constitution ?? 0)" /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                            </tr>
+                            <tr>
+                                <th class="ability-name">
+                                    <div class="abbr">INT</div>
+                                    <div class="full">Intelligence</div>
+                                </th>
+                                <td><input class="form-control text-center" readonly value="@Model?.Intelligence" /></td>
+                                <td><input class="form-control text-center" readonly value="@Mod(Model?.Intelligence ?? 0)" /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                            </tr>
+                            <tr>
+                                <th class="ability-name">
+                                    <div class="abbr">WIS</div>
+                                    <div class="full">Wisdom</div>
+                                </th>
+                                <td><input class="form-control text-center" readonly value="@Model?.Wisdom" /></td>
+                                <td><input class="form-control text-center" readonly value="@Mod(Model?.Wisdom ?? 0)" /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                            </tr>
+                            <tr>
+                                <th class="ability-name">
+                                    <div class="abbr">CHA</div>
+                                    <div class="full">Charisma</div>
+                                </th>
+                                <td><input class="form-control text-center" readonly value="@Model?.Charisma" /></td>
+                                <td><input class="form-control text-center" readonly value="@Mod(Model?.Charisma ?? 0)" /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                                <td><input class="form-control text-center" readonly /></td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/Lugamar VTT/wwwroot/css/charsheet.css
+++ b/Lugamar VTT/wwwroot/css/charsheet.css
@@ -1,22 +1,37 @@
-.ability-scores {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-}
 
-.ability {
-    border: 2px solid #000;
+/* Ability score table */
+.ability-table th,
+.ability-table td {
     text-align: center;
-    padding: 0.5rem;
-    background-color: #f8f9fa;
-    border-radius: .25rem;
-    width: 80px;
+    vertical-align: middle;
 }
 
-.ability label {
+.ability-table .ability-name {
+    padding: 0;
+    width: 120px;
+}
+
+.ability-table .ability-name .abbr {
+    background-color: #000;
+    color: #fff;
     font-weight: bold;
-    font-size: 0.8rem;
-    display:block;
+    padding: 0.25rem 0;
+    display: block;
+}
+
+.ability-table .ability-name .full {
+    background-color: #f8f9fa;
+    font-size: 0.75rem;
+    padding: 0.25rem 0;
+    display: block;
+}
+
+.ability-table input {
+    width: 3.5rem;
+    height: 3.5rem;
+    padding: 0;
+    text-align: center;
+    margin: 0 auto;
 }
 
 .sheet-table input {


### PR DESCRIPTION
## Summary
- Reshape Ability Scores card into a table matching Pathfinder sheet layout with columns for score, modifier, and adjustments
- Add dedicated CSS to style ability labels and square input boxes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b06fee995c833098f71e13d8abc695