### PR TITLE
Enhance Special Abilities card with modal and summary

### DIFF
--- a/Lugamar VTT/Models/SpecialAbility.cs
+++ b/Lugamar VTT/Models/SpecialAbility.cs
@@ -10,6 +10,9 @@ namespace LugamarVTT.Models
     {
         public string Name { get; set; } = string.Empty;
         public string Source { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public int Level { get; set; }
+        public string Summary { get; set; } = string.Empty;
         /// <summary>Formatted description of the ability.</summary>
         public MarkupString Text { get; set; } = new MarkupString();
     }

--- a/Lugamar VTT/Services/XmlDataService.cs
+++ b/Lugamar VTT/Services/XmlDataService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace LugamarVTT.Services
@@ -433,7 +434,16 @@ namespace LugamarVTT.Services
                     var name = GetString(ability.Element("name")) ?? string.Empty;
                     var source = GetString(ability.Element("source")) ?? string.Empty;
                     var type = GetString(ability.Element("type")) ?? string.Empty;
-                    var text = GetString(ability.Element("text"));
+                    var level = GetInt(ability.Element("level"));
+                    var text = GetString(ability.Element("text")) ?? string.Empty;
+                    var summary = string.Empty;
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        var plainText = Regex.Replace(text, "<.*?>", string.Empty);
+                        var first = plainText.Split('.', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                        if (!string.IsNullOrWhiteSpace(first))
+                            summary = first.Trim() + ".";
+                    }
 
                     if (!string.IsNullOrEmpty(type) && type.Contains("Trait", System.StringComparison.OrdinalIgnoreCase))
                     {
@@ -451,6 +461,9 @@ namespace LugamarVTT.Services
                         {
                             Name = name,
                             Source = source,
+                            Type = type,
+                            Level = level,
+                            Summary = summary,
                             Text = (MarkupString)text
                         });
                     }

--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -508,16 +508,20 @@
                         <thead>
                             <tr>
                                 <th><b>Name</b></th>
-                                <th><b>Source</b></th>
-                                <th><b>Text</b></th>
+                                <th><b>Summary</b></th>
                             </tr>
                         </thead>
                         <tbody>
                             @foreach (var ability in Model.SpecialAbilities) {
-                                <tr>
+                                <tr style="cursor:pointer"
+                                    data-bs-toggle="modal" data-bs-target="#abilityModal"
+                                    data-name="@ability.Name"
+                                    data-type="@ability.Type"
+                                    data-level="@ability.Level"
+                                    data-source="@ability.Source"
+                                    data-text='@(ability.Text.Value ?? "")'>
                                     <td><span readonly>@ability.Name</span></td>
-                                    <td><span readonly>@ability.Source</span></td>
-                                    <td><span readonly>@ability.Text</span></td>
+                                    <td><span readonly>@ability.Summary</span></td>
                                 </tr>
                             }
                         </tbody>
@@ -620,6 +624,22 @@
         </div>
     </div>
     }
+    <div class="modal fade" id="abilityModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="abilityModalTitle"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p><strong>Type:</strong> <span id="abilityModalType"></span></p>
+                    <p><strong>Level:</strong> <span id="abilityModalLevel"></span></p>
+                    <p><strong>Source:</strong> <span id="abilityModalSource"></span></p>
+                    <div id="abilityModalText"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="modal fade" id="permModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
@@ -657,6 +677,16 @@
                 row.innerHTML = `<td>${p.permNum ?? ''}</td><td>${p.bonusType ?? ''}</td><td>${p.name ?? ''}</td>`;
                 body.appendChild(row);
             });
+        });
+
+        const abilityModal = document.getElementById('abilityModal');
+        abilityModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            abilityModal.querySelector('#abilityModalTitle').textContent = button.getAttribute('data-name') || '';
+            abilityModal.querySelector('#abilityModalType').textContent = button.getAttribute('data-type') || '';
+            abilityModal.querySelector('#abilityModalLevel').textContent = button.getAttribute('data-level') || '';
+            abilityModal.querySelector('#abilityModalSource').textContent = button.getAttribute('data-source') || '';
+            abilityModal.querySelector('#abilityModalText').innerHTML = button.getAttribute('data-text') || '';
         });
     </script>
 }


### PR DESCRIPTION
## Summary
- Add type, level, and summary fields to special abilities and parse them from XML
- Show special abilities with summaries and open modal on click to view full details rendered as HTML

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b1decd0aa08330874f7c43b37e4fa3