### PR TITLE
Display initiative and speed breakdown

### DIFF
--- a/Lugamar VTT/Models/Character.cs
+++ b/Lugamar VTT/Models/Character.cs
@@ -60,8 +60,8 @@ namespace LugamarVTT.Models
         public SavingThrowDetail Fortitude { get; set; } = new();
         public SavingThrowDetail Reflex { get; set; } = new();
         public SavingThrowDetail Will { get; set; } = new();
-        public int Initiative { get; set; }
-        public int Speed { get; set; }
+        public InitiativeDetail Initiative { get; set; } = new();
+        public SpeedDetail Speed { get; set; } = new();
         public int BaseAttackBonus { get; set; }
         public AttackBonusDetail MeleeAttackBonus { get; set; } = new();
         public AttackBonusDetail RangedAttackBonus { get; set; } = new();

--- a/Lugamar VTT/Models/InitiativeDetail.cs
+++ b/Lugamar VTT/Models/InitiativeDetail.cs
@@ -1,0 +1,13 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents the components that make up initiative.
+    /// </summary>
+    public class InitiativeDetail
+    {
+        public int AbilityMod { get; set; }
+        public int Misc { get; set; }
+        public int Temp { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/Lugamar VTT/Models/SpeedDetail.cs
+++ b/Lugamar VTT/Models/SpeedDetail.cs
@@ -1,0 +1,14 @@
+namespace LugamarVTT.Models
+{
+    /// <summary>
+    /// Represents the components that make up speed.
+    /// </summary>
+    public class SpeedDetail
+    {
+        public int Base { get; set; }
+        public int Armor { get; set; }
+        public int Misc { get; set; }
+        public int Temp { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/Lugamar VTT/Services/XmlDataService.cs
+++ b/Lugamar VTT/Services/XmlDataService.cs
@@ -149,6 +149,21 @@ namespace LugamarVTT.Services
                 Temp = GetInt(node?.Element("temporary")),
                 Total = GetInt(node?.Element("total"))
             };
+            static InitiativeDetail ParseInitiative(XElement? node) => new InitiativeDetail
+            {
+                AbilityMod = GetInt(node?.Element("abilitymod")),
+                Misc = GetInt(node?.Element("misc")),
+                Temp = GetInt(node?.Element("temporary")),
+                Total = GetInt(node?.Element("total"))
+            };
+            static SpeedDetail ParseSpeed(XElement? node) => new SpeedDetail
+            {
+                Base = GetInt(node?.Element("base")),
+                Armor = GetInt(node?.Element("armor")),
+                Misc = GetInt(node?.Element("misc")),
+                Temp = GetInt(node?.Element("temporary")),
+                Total = GetInt(node?.Element("total"))
+            };
 
             // Ability scores are nested within <abilities>/<ability>/<score>.
             var abilities = charNode.Element("abilities");
@@ -210,8 +225,8 @@ namespace LugamarVTT.Services
                 Fortitude = ParseSave(savesNode?.Element("fortitude")),
                 Reflex = ParseSave(savesNode?.Element("reflex")),
                 Will = ParseSave(savesNode?.Element("will")),
-                Initiative = GetInt(charNode.Element("initiative")?.Element("total")),
-                Speed = GetInt(charNode.Element("speed")?.Element("total")),
+                Initiative = ParseInitiative(charNode.Element("initiative")),
+                Speed = ParseSpeed(charNode.Element("speed")),
                 BaseAttackBonus = baseAttack,
                 SkillPointsSpent = GetInt(charNode.Element("skillpoints")?.Element("spent"))
             };

--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -113,10 +113,10 @@
         </div>
     </div>
 
-    <!-- Row 2: Ability Scores & Saving Throws; Hit Points, Initiative & Speed -->
+    <!-- Row 2: Ability Scores & Hit Points -->
     <div class="row mb-4">
         <div class="col-md-6 mb-4 mb-md-0">
-            <div class="card shadow-sm mb-4">
+            <div class="card shadow-sm">
                 <div class="card-header">Ability Scores</div>
                 <div class="card-body full-border">
 @{
@@ -171,52 +171,9 @@
                     </table>
                 </div>
             </div>
-            <div class="card shadow-sm">
-                <div class="card-header">Saving Throws</div>
-                <div class="card-body full-border">
-                    <table class="table table-sm table-striped sheet-table mb-0 saving-throws-table">
-                        <thead>
-                            <tr>
-                                <th></th>
-                                <th><b>Total</b></th>
-                                <th><b>Class</b></th>
-                                <th><b>Stat</b></th>
-                                <th><b>Misc</b></th>
-                                <th><b>Temp</b></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>Fortitude</td>
-                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Total" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Base" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.AbilityMod" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Misc" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Temp" /></td>
-                            </tr>
-                            <tr>
-                                <td>Reflex</td>
-                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Total" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Base" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.AbilityMod" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Misc" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Temp" /></td>
-                            </tr>
-                            <tr>
-                                <td>Will</td>
-                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Will.Total" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.Base" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.AbilityMod" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.Misc" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.Temp" /></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
         </div>
         <div class="col-md-6">
-            <div class="card shadow-sm mb-4">
+            <div class="card shadow-sm">
                 <div class="card-header">Hit Points</div>
                 <div class="card-body">
                     <div class="row mb-3 full-border">
@@ -265,23 +222,108 @@
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <!-- Row 3: Saving Throws & Initiative & Speed -->
+    <div class="row mb-4">
+        <div class="col-md-6 mb-4 mb-md-0">
+            <div class="card shadow-sm">
+                <div class="card-header">Saving Throws</div>
+                <div class="card-body full-border">
+                    <table class="table table-sm table-striped sheet-table mb-0 saving-throws-table">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th><b>Total</b></th>
+                                <th><b>Class</b></th>
+                                <th><b>Stat</b></th>
+                                <th><b>Misc</b></th>
+                                <th><b>Temp</b></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Fortitude</td>
+                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Total" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Base" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.AbilityMod" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Misc" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Fortitude.Temp" /></td>
+                            </tr>
+                            <tr>
+                                <td>Reflex</td>
+                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Total" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Base" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.AbilityMod" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Misc" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Reflex.Temp" /></td>
+                            </tr>
+                            <tr>
+                                <td>Will</td>
+                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Will.Total" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.Base" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.AbilityMod" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.Misc" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Will.Temp" /></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
             <div class="card shadow-sm">
                 <div class="card-header">Initiative &amp; Speed</div>
                 <div class="card-body full-border">
-                    <div class="mb-3">
-                        <label class="form-label">Initiative</label>
-                        <input class="form-control" readonly value="@Model?.Initiative" />
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Speed</label>
-                        <input class="form-control" readonly value="@Model?.Speed" />
-                    </div>
+                    <table class="table table-sm table-striped sheet-table mb-3 saving-throws-table">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th><b>Total</b></th>
+                                <th><b>Stat</b></th>
+                                <th><b>Misc</b></th>
+                                <th><b>Temp</b></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Initiative</td>
+                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Total" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.AbilityMod" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Misc" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Temp" /></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <table class="table table-sm table-striped sheet-table mb-0 saving-throws-table">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th><b>Total</b></th>
+                                <th><b>Base</b></th>
+                                <th><b>Armor</b></th>
+                                <th><b>Misc</b></th>
+                                <th><b>Temp</b></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Speed</td>
+                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Speed.Total" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Base" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Armor" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Misc" /></td>
+                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Temp" /></td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Row 3: Armor Class -->
+    <!-- Row 4: Armor Class -->
     <div class="row mb-4">
         <div class="col">
             <div class="card shadow-sm">
@@ -374,7 +416,7 @@
         </div>
     </div>
 
-    <!-- Row 4: Attack Bonus -->
+    <!-- Row 5: Attack Bonus -->
     <div class="row mb-4">
         <div class="col">
             <div class="card shadow-sm">
@@ -435,7 +477,7 @@
         </div>
     </div>
 
-    <!-- Row 5: Skills -->
+    <!-- Row 6: Skills -->
     @if (Model != null && Model.SkillDetails.Any()) {
     <div class="row mb-4">
         <div class="col">
@@ -472,7 +514,7 @@
     </div>
     }
 
-    <!-- Row 6: Feats; Special Abilities -->
+    <!-- Row 7: Feats; Special Abilities -->
     <div class="row mb-4">
         @if (Model != null && Model.FeatDetails.Any()) {
         <div class="col-md-6 mb-4 mb-md-0">
@@ -539,7 +581,7 @@
         }
     </div>
 
-    <!-- Row 7: Proficiencies; Traits -->
+    <!-- Row 8: Proficiencies; Traits -->
     <div class="row mb-4">
         @if (Model != null && Model.Proficiencies.Any()) {
         <div class="col-md-6 mb-4 mb-md-0">
@@ -584,7 +626,7 @@
         }
     </div>
 
-    <!-- Row 8: Equipment -->
+    <!-- Row 9: Equipment -->
     @if (Model != null && Model.EquipmentDetails.Any()) {
     <div class="row mb-4">
         <div class="col">
@@ -620,7 +662,7 @@
     </div>
     }
 
-    <!-- Row 9: Spells -->
+    <!-- Row 10: Spells -->
     @if (Model != null && Model.Spells.Any()) {
     <div class="row mb-4">
         <div class="col">

--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -14,7 +14,6 @@
 }
 
 
-<h1 class="mt-4 mb-3">@Model?.Name</h1>
 <a asp-action="Index" class="btn btn-secondary mb-3">&larr; Back to list</a>
 
 <div class="charsheet">
@@ -280,43 +279,43 @@
                         <tbody>
                             <tr>
                                 <td>Initiative</td>
-                                <td class="total text-center">
+                                <td class="total">
                                     <input class="form-control form-control-sm" readonly value="@Model?.Initiative.Total" />
-                                    <label class="form-label small w-100">Total</label>
+                                    <label class="form-label small w-100">&nbsp;</label>
                                 </td>
-                                <td class="text-center">
+                                <td>
                                     <input class="form-control form-control-sm" readonly value="@Model?.Initiative.AbilityMod" />
                                     <label class="form-label small w-100">Stat</label>
                                 </td>
                                 <td></td>
-                                <td class="text-center">
+                                <td>
                                     <input class="form-control form-control-sm" readonly value="@Model?.Initiative.Misc" />
                                     <label class="form-label small w-100">Misc</label>
                                 </td>
-                                <td class="text-center">
+                                <td>
                                     <input class="form-control form-control-sm" readonly value="@Model?.Initiative.Temp" />
                                     <label class="form-label small w-100">Temp</label>
                                 </td>
                             </tr>
                             <tr>
                                 <td>Speed</td>
-                                <td class="total text-center">
+                                <td class="total">
                                     <input class="form-control form-control-sm" readonly value="@Model?.Speed.Total" />
-                                    <label class="form-label small w-100">Total</label>
+                                    <label class="form-label small w-100">&nbsp;</label>
                                 </td>
-                                <td class="text-center">
+                                <td>
                                     <input class="form-control form-control-sm" readonly value="@Model?.Speed.Base" />
                                     <label class="form-label small w-100">Base</label>
                                 </td>
-                                <td class="text-center">
+                                <td>
                                     <input class="form-control form-control-sm" readonly value="@Model?.Speed.Armor" />
                                     <label class="form-label small w-100">Armor</label>
                                 </td>
-                                <td class="text-center">
+                                <td>
                                     <input class="form-control form-control-sm" readonly value="@Model?.Speed.Misc" />
                                     <label class="form-label small w-100">Misc</label>
                                 </td>
-                                <td class="text-center">
+                                <td>
                                     <input class="form-control form-control-sm" readonly value="@Model?.Speed.Temp" />
                                     <label class="form-label small w-100">Temp</label>
                                 </td>

--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -277,32 +277,49 @@
                 <div class="card-header">Initiative &amp; Speed</div>
                 <div class="card-body full-border">
                     <table class="table table-sm table-striped sheet-table mb-0 saving-throws-table">
-                        <thead>
-                            <tr>
-                                <th></th>
-                                <th><b>Total</b></th>
-                                <th><b>Stat/Base</b></th>
-                                <th><b>Armor</b></th>
-                                <th><b>Misc</b></th>
-                                <th><b>Temp</b></th>
-                            </tr>
-                        </thead>
                         <tbody>
                             <tr>
                                 <td>Initiative</td>
-                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Total" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.AbilityMod" /></td>
+                                <td class="total text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Initiative.Total" />
+                                    <label class="form-label small w-100">Total</label>
+                                </td>
+                                <td class="text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Initiative.AbilityMod" />
+                                    <label class="form-label small w-100">Stat</label>
+                                </td>
                                 <td></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Misc" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Temp" /></td>
+                                <td class="text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Initiative.Misc" />
+                                    <label class="form-label small w-100">Misc</label>
+                                </td>
+                                <td class="text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Initiative.Temp" />
+                                    <label class="form-label small w-100">Temp</label>
+                                </td>
                             </tr>
                             <tr>
                                 <td>Speed</td>
-                                <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Speed.Total" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Base" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Armor" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Misc" /></td>
-                                <td><input class="form-control form-control-sm" readonly value="@Model?.Speed.Temp" /></td>
+                                <td class="total text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Speed.Total" />
+                                    <label class="form-label small w-100">Total</label>
+                                </td>
+                                <td class="text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Speed.Base" />
+                                    <label class="form-label small w-100">Base</label>
+                                </td>
+                                <td class="text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Speed.Armor" />
+                                    <label class="form-label small w-100">Armor</label>
+                                </td>
+                                <td class="text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Speed.Misc" />
+                                    <label class="form-label small w-100">Misc</label>
+                                </td>
+                                <td class="text-center">
+                                    <input class="form-control form-control-sm" readonly value="@Model?.Speed.Temp" />
+                                    <label class="form-label small w-100">Temp</label>
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -276,12 +276,13 @@
             <div class="card shadow-sm">
                 <div class="card-header">Initiative &amp; Speed</div>
                 <div class="card-body full-border">
-                    <table class="table table-sm table-striped sheet-table mb-3 saving-throws-table">
+                    <table class="table table-sm table-striped sheet-table mb-0 saving-throws-table">
                         <thead>
                             <tr>
                                 <th></th>
                                 <th><b>Total</b></th>
-                                <th><b>Stat</b></th>
+                                <th><b>Stat/Base</b></th>
+                                <th><b>Armor</b></th>
                                 <th><b>Misc</b></th>
                                 <th><b>Temp</b></th>
                             </tr>
@@ -291,23 +292,10 @@
                                 <td>Initiative</td>
                                 <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Total" /></td>
                                 <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.AbilityMod" /></td>
+                                <td></td>
                                 <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Misc" /></td>
                                 <td><input class="form-control form-control-sm" readonly value="@Model?.Initiative.Temp" /></td>
                             </tr>
-                        </tbody>
-                    </table>
-                    <table class="table table-sm table-striped sheet-table mb-0 saving-throws-table">
-                        <thead>
-                            <tr>
-                                <th></th>
-                                <th><b>Total</b></th>
-                                <th><b>Base</b></th>
-                                <th><b>Armor</b></th>
-                                <th><b>Misc</b></th>
-                                <th><b>Temp</b></th>
-                            </tr>
-                        </thead>
-                        <tbody>
                             <tr>
                                 <td>Speed</td>
                                 <td class="total"><input class="form-control form-control-sm" readonly value="@Model?.Speed.Total" /></td>

--- a/Lugamar VTT/wwwroot/css/charsheet.css
+++ b/Lugamar VTT/wwwroot/css/charsheet.css
@@ -101,7 +101,7 @@ BODY {
 
 /* Saving throws table */
 .saving-throws-table input {
-    width: 40px;
+    width: 45px;
 }
 /* Total column styling */
 .card .card-body td.total input,


### PR DESCRIPTION
## Summary
- Expand `Character` model with `InitiativeDetail` and `SpeedDetail` to capture stat, misc and temp modifiers
- Parse initiative and speed components from XML data and surface in the UI
- Split layout so Initiative & Speed card aligns with Saving Throws, displaying detailed tables for each

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b213b0401083308bdde0c61ed460c9