### PR TITLE
Enhance equipment card with identification and details modal

### DIFF
--- a/Lugamar VTT/Models/EquipmentItem.cs
+++ b/Lugamar VTT/Models/EquipmentItem.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace LugamarVTT.Models
 {
     /// <summary>
@@ -11,7 +13,16 @@ namespace LugamarVTT.Models
         public string Subtype { get; set; } = string.Empty;
         public string Cost { get; set; } = string.Empty;
         public string Weight { get; set; } = string.Empty;
+
         /// <summary>Formatted description of the item.</summary>
         public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Raw details parsed from the XML node. Keys are the original element
+        /// names (e.g. "type", "weight") and values are the formatted string
+        /// representations.  This is used to dynamically render a modal with
+        /// item details on the character sheet.
+        /// </summary>
+        public Dictionary<string, string> Details { get; set; } = new();
     }
 }

--- a/Lugamar VTT/Views/Charsheet/Details.cshtml
+++ b/Lugamar VTT/Views/Charsheet/Details.cshtml
@@ -7,6 +7,7 @@
 
 @{
     ViewData["Title"] = Model?.Name ?? "Character Details";
+    var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 }
 
 @section Styles {
@@ -128,7 +129,6 @@
         new { Key = "wisdom", Abbr = "WIS", Full = "Wisdom" },
         new { Key = "charisma", Abbr = "CHA", Full = "Charisma" }
     };
-    var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 }
                     <table class="table ability-table mb-0">
                         <thead>
@@ -650,7 +650,9 @@
                             </thead>
                             <tbody>
                                 @foreach (var item in group) {
-                                    <tr>
+                                    <tr role="button" data-bs-toggle="modal" data-bs-target="#equipmentModal"
+                                        data-name="@item.Name"
+                                        data-details="@JsonSerializer.Serialize(item.Details, jsonOptions)">
                                         <td><span>@item.Name</span></td>
                                         <td><span>@item.Subtype</span></td>
                                         <td><span>@item.Cost</span></td>
@@ -679,6 +681,17 @@
         </div>
     </div>
     }
+    <div class="modal fade" id="equipmentModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="equipmentModalTitle"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body" id="equipmentModalBody"></div>
+            </div>
+        </div>
+    </div>
     <div class="modal fade" id="featModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered modal-lg">
             <div class="modal-content">
@@ -771,6 +784,22 @@
                 const row = document.createElement('tr');
                 row.innerHTML = `<td>${p.permNum ?? ''}</td><td>${p.bonusType ?? ''}</td><td>${p.name ?? ''}</td>`;
                 body.appendChild(row);
+            });
+        });
+
+        const equipmentModal = document.getElementById('equipmentModal');
+        equipmentModal.addEventListener('show.bs.modal', event => {
+            const button = event.relatedTarget;
+            equipmentModal.querySelector('#equipmentModalTitle').textContent = button.getAttribute('data-name') || '';
+            const details = JSON.parse(button.getAttribute('data-details') || '{}');
+            const body = equipmentModal.querySelector('#equipmentModalBody');
+            body.innerHTML = '';
+            Object.entries(details).forEach(([key, value]) => {
+                if (!value || value.trim() === '') return;
+                const p = document.createElement('p');
+                const label = key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+                p.innerHTML = `<strong>${label}:</strong> ${value}`;
+                body.appendChild(p);
             });
         });
 

--- a/LugamarVTT.Tests/XmlDataServiceTests.cs
+++ b/LugamarVTT.Tests/XmlDataServiceTests.cs
@@ -75,6 +75,57 @@ public class XmlDataServiceTests
     }
 
     [Fact]
+    public void GetCharacters_ParsesEquipmentIdentificationAndCostVisibility()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "db.xml"), """
+<root>
+  <charsheet>
+    <inventorylist>
+      <id-00001>
+        <name>Longsword</name>
+        <nonid_name>Mysterious Blade</nonid_name>
+        <isidentified>0</isidentified>
+        <cost>50 gp</cost>
+        <cost_visibility>0</cost_visibility>
+        <weight>3 lbs</weight>
+        <gmonly>secret</gmonly>
+      </id-00001>
+      <id-00002>
+        <name>Ring</name>
+        <isidentified>0</isidentified>
+      </id-00002>
+    </inventorylist>
+  </charsheet>
+</root>
+""");
+
+            var env = new TestHostEnvironment(tempDir);
+            var service = new XmlDataService(NullLogger<XmlDataService>.Instance, env);
+
+            var character = service.GetCharacters().Single();
+
+            var first = character.EquipmentDetails[0];
+            Assert.Equal("Mysterious Blade", first.Name);
+            Assert.Equal(string.Empty, first.Cost);
+            Assert.Equal("3 lbs", first.Weight);
+            Assert.DoesNotContain("gmonly", first.Details.Keys);
+            Assert.DoesNotContain("isidentified", first.Details.Keys);
+            Assert.DoesNotContain("cost_visibility", first.Details.Keys);
+
+            var second = character.EquipmentDetails[1];
+            Assert.Equal("Unknown Item", second.Name);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void GetCharacters_ParsesArmorClassDeflectionAndTemp()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());


### PR DESCRIPTION
## Summary
- Respect item identification and cost visibility when parsing equipment
- Display equipment details in a modal and hide GM-only fields
- Test equipment parsing for identification and cost visibility

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b2238e66208330bace51c33b4174f2